### PR TITLE
feat(cli-commands): adding (en|de)crypt commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,4 @@ clean:
 	@find $(ROOT_DIR) -name ".DS_Store" -type f -exec rm -r {} +
 	@find $(ROOT_DIR) -type d -name __pycache__ -exec rm -r {} +
 	@find $(ROOT_DIR) -type d -name "*.pytest_cache*" -exec rm -r {} +
+	@find $(ROOT_DIR) -type d -name "*.mypy_cache*" -exec rm -r {} +

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -15,6 +15,8 @@ Options:
 
 Commands:
   backup                  Backup current macOS installation.
+  decrypt                 Decrypt an encrypted backup file.
+  encrypt                 Encrypt an unencrypted backup file.
   print-backup-locations  Print base backup locations.
   restore                 Restore a previous macOS installation backup.
 ```
@@ -27,10 +29,36 @@ Usage: macos-install backup [OPTIONS]
   Backup current macOS installation.
 
 Options:
-  -b, --backup-file PATH     Location of backup zip file  [required]
+  -b, --backup-file PATH     Location of backup/restore ZIP file  [required]
   -l, --extra-location PATH  Extra location to back up; multiple allowed
-  -p, --password TEXT        Password to encrypt backup file
+  -p, --password TEXT        Password to decrypt/encrypt backup file
   --help                     Show this message and exit.
+```
+
+### decrypt
+
+```console
+Usage: macos-install decrypt [OPTIONS]
+
+  Decrypt an encrypted backup file.
+
+Options:
+  -b, --backup-file PATH  Location of backup/restore ZIP file  [required]
+  -p, --password TEXT     Password to decrypt/encrypt backup file  [required]
+  --help                  Show this message and exit.
+```
+
+### encrypt
+
+```console
+Usage: macos-install encrypt [OPTIONS]
+
+  Encrypt an unencrypted backup file.
+
+Options:
+  -b, --backup-file PATH  Location of backup/restore ZIP file  [required]
+  -p, --password TEXT     Password to decrypt/encrypt backup file  [required]
+  --help                  Show this message and exit.
 ```
 
 ### print-backup-locations
@@ -54,7 +82,7 @@ Usage: macos-install restore [OPTIONS]
   Restore a previous macOS installation backup.
 
 Options:
-  -p, --password TEXT      Password to decrypt backup file
-  -r, --restore-file PATH  Location of restore ZIP file  [required]
-  --help                   Show this message and exit.
+  -b, --backup-file PATH  Location of backup/restore ZIP file  [required]
+  -p, --password TEXT     Password to decrypt/encrypt backup file
+  --help                  Show this message and exit.
 ```

--- a/src/macos_installation/classes/zip.py
+++ b/src/macos_installation/classes/zip.py
@@ -144,7 +144,7 @@ class InMemoryZip(object):
 
         return contents
 
-    def write_to_file(self, filename) -> t.NoReturn:
+    def write_to_file(self, filename: pathlib.Path) -> t.NoReturn:
         """
         The write_to_file function writes the contents of the file to a new file.
 

--- a/src/macos_installation/cli/decorators.py
+++ b/src/macos_installation/cli/decorators.py
@@ -1,0 +1,46 @@
+import pathlib
+import typing as t
+
+import click
+
+from macos_installation import config
+
+
+def common_backup_file(exists: bool = True) -> t.Callable:
+    def inner_f(f):
+        f = click.option(
+            "-b",
+            "--backup-file",
+            help="Location of backup/restore ZIP file",
+            required=True,
+            type=click.Path(exists=exists, path_type=pathlib.Path, resolve_path=True),
+            **config.BASE_CLI_OPTIONS,
+        )(f)
+
+        return f
+
+    return inner_f
+
+
+def common_password(
+    confirmation_prompt: bool = True,
+    prompt_required: bool = False,
+    required: bool = False,
+) -> t.Callable:
+    def inner_f(f):
+        f = click.option(
+            "-p",
+            "--password",
+            confirmation_prompt=confirmation_prompt,
+            help="Password to decrypt/encrypt backup file",
+            hide_input=True,
+            prompt=True,
+            prompt_required=prompt_required,
+            required=required,
+            type=str,
+            **config.BASE_CLI_OPTIONS,
+        )(f)
+
+        return f
+
+    return inner_f

--- a/src/macos_installation/cli/decrypt.py
+++ b/src/macos_installation/cli/decrypt.py
@@ -1,0 +1,22 @@
+import pathlib
+import typing as t
+
+import click
+
+from macos_installation.classes.zip import InMemoryZip
+
+
+class DecryptCommand(object):
+    def __init__(self, zip_object: InMemoryZip, **kwargs):
+        self.debug: bool = kwargs["debug"]
+        self.dry_run: bool = kwargs["dry_run"]
+
+        self.__zip_object = zip_object
+
+    def main(self) -> t.NoReturn:
+        self.__zip_object.decrypt()
+        decrypted_file_path = pathlib.Path(
+            f"{str(self.__zip_object.file_path.absolute()).replace('.enc', '')}"
+        )
+        self.__zip_object.write_to_file(decrypted_file_path)
+        click.secho(f"Decrypted file written to '{decrypted_file_path}'", fg="green")

--- a/src/macos_installation/cli/encrypt.py
+++ b/src/macos_installation/cli/encrypt.py
@@ -1,0 +1,22 @@
+import pathlib
+import typing as t
+
+import click
+
+from macos_installation.classes.zip import InMemoryZip
+
+
+class EncryptCommand(object):
+    def __init__(self, zip_object: InMemoryZip, **kwargs):
+        self.debug: bool = kwargs["debug"]
+        self.dry_run: bool = kwargs["dry_run"]
+
+        self.__zip_object = zip_object
+
+    def main(self) -> t.NoReturn:
+        self.__zip_object.encrypt()
+        encrypted_file_path = pathlib.Path(
+            f"{self.__zip_object.file_path.absolute()}.enc"
+        )
+        self.__zip_object.write_to_file(encrypted_file_path)
+        click.secho(f"Encrypted file written to '{encrypted_file_path}'", fg="green")


### PR DESCRIPTION
# Description

Sometimes it may be desired to encrypt an already existing backup file, and to decrypt it without a backup / restore operation attached.