### PR TITLE
fix(scripts): adding newline for proper spacing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,12 @@ clean:
 	@find $(ROOT_DIR) -type d -name __pycache__ -exec rm -r {} +
 	@find $(ROOT_DIR) -type d -name "*.pytest_cache*" -exec rm -r {} +
 	@find $(ROOT_DIR) -type d -name "*.mypy_cache*" -exec rm -r {} +
+
+# ==================================================================================== #
+# TASK
+# ==================================================================================== #
+
+## task/update-cli-docs: updates the cli docs for new options / flags
+.PHONY: task/update-cli-docs
+task/update-cli-docs:
+	@$(ROOT_DIR)/scripts/generate-docs.py > $(ROOT_DIR)/docs/commands.md

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -27,7 +27,7 @@ def recursive_help(
             )
         )
     else:
-        print(f"{section} {cmd.name}\n")
+        print(f"\n{section} {cmd.name}\n")
 
     print("```console")
     print(cmd.get_help(ctx).replace("Usage: cli-entrypoint", "Usage: macos-install"))


### PR DESCRIPTION
# Description

This adds a quick newline for the proper spacing needs for `docs/commands.md`.