### PR TITLE
refactor(data): adding class for backup manifest

### DIFF
--- a/src/macos_installation/classes/data.py
+++ b/src/macos_installation/classes/data.py
@@ -1,4 +1,9 @@
 import dataclasses
+import pathlib
+import typing as t
+
+from macos_installation import config
+from macos_installation.functions import util
 
 
 @dataclasses.dataclass
@@ -8,6 +13,7 @@ class EncryptedData:
     nonce_size: int = dataclasses.field(default=16)
     tag_size: int = dataclasses.field(default=16)
 
+    # Initialized later
     salt: bytes = dataclasses.field(init=False)
     nonce: bytes = dataclasses.field(init=False)
     raw_data: bytes = dataclasses.field(init=False)
@@ -22,3 +28,32 @@ class EncryptedData:
             (self.salt_size + self.nonce_size) : -(self.tag_size)
         ]
         self.tag: bytes = self.encrypted_data[-(self.tag_size) :]
+
+
+@dataclasses.dataclass
+class BackupManifest:
+    backup_locations: t.List[t.Union[str, pathlib.Path]]
+    existing: bool = dataclasses.field(default=False)
+    old_user: str = dataclasses.field(default=config.CURRENT_USER)
+    old_user_home_dir: str = dataclasses.field(default=config.CURRENT_USER_HOME_DIR)
+
+    # Initialized later
+    all_backup_files: t.List[pathlib.Path] = None
+    file_digests: t.Dict[str, str] = None
+
+    def __post_init__(self):
+        if not self.existing:
+            self.all_backup_files = [
+                location
+                for location in util.get_recursive_file_list(self.backup_locations)
+            ]
+            self.file_digests = {
+                str(f): util.get_file_sha256_hash(f) for f in self.all_backup_files
+            }
+
+    def dict(self):
+        return {
+            k: v
+            for k, v in dataclasses.asdict(self).items()
+            if k not in ["all_backup_files", "existing"]
+        }

--- a/src/macos_installation/classes/zip.py
+++ b/src/macos_installation/classes/zip.py
@@ -18,11 +18,13 @@ class InMemoryZip(object):
     def __init__(
         self, file: t.Optional[pathlib.Path] = None, password: t.Optional[str] = None
     ):
+        # Inputs
         self.file_path = file
-        self.zip_contents = io.BytesIO(
+        self.__password = password
+
+        self.zip_contents: t.Optional[t.IO[bytes]] = io.BytesIO(
             self.file_path.read_bytes() if self.file_path else None
         )
-        self.__password = password
 
         logger.debug(f"Class 'InMemoryZip' instantiated: {pformat(self.__dict__)}")
 

--- a/src/macos_installation/cli/decorators.py
+++ b/src/macos_installation/cli/decorators.py
@@ -8,6 +8,14 @@ from macos_installation import config
 
 def common_backup_file(exists: bool = True) -> t.Callable:
     def inner_f(f):
+        """
+        The inner_f function is a decorator that takes the function f as an argument.
+        It then adds the click option -b/--backup-file to it, which is required and has a help message.
+        The inner_f function returns f with this added functionality.
+
+        :param f: Pass the function to be decorated
+        :return: The function f with the added option
+        """
         f = click.option(
             "-b",
             "--backup-file",
@@ -27,6 +35,17 @@ def common_password(
     prompt_required: bool = False,
     required: bool = False,
 ) -> t.Callable:
+    """
+    The common_password function is a decorator that adds the common password
+    option to a click command. The common_password option is used for decrypting
+    backup files and encrypting new backups. It has several options:
+
+    :param confirmation_prompt:bool=True: Determine if the user should be prompted for a confirmation of their password
+    :param prompt_required:bool=False: Determine if the password prompt should be shown
+    :param required:bool=False: Tell click that the parameter is not required
+    :return: A function that is decorated with the click
+    """
+
     def inner_f(f):
         f = click.option(
             "-p",


### PR DESCRIPTION
# Description

The `BackupManifest` dataclass provides a nicer way of dealing with the backup manifest that's placed inside of the ZIP file.