### PR TITLE
fix(scripts): fixing command string replacement

### DIFF
--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -30,7 +30,7 @@ def recursive_help(
         print(f"\n{section} {cmd.name}\n")
 
     print("```console")
-    print(cmd.get_help(ctx).replace("Usage: cli-entrypoint", "Usage: macos-install"))
+    print(cmd.get_help(ctx))
     print("```")
 
     commands = getattr(cmd, "commands", {})

--- a/src/macos_installation/cli/__init__.py
+++ b/src/macos_installation/cli/__init__.py
@@ -22,7 +22,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------
 
 
-@click.group()
+@click.group("macos-install")
 @click.option(
     "--debug/--no-debug",
     default=False,


### PR DESCRIPTION
# Description

Previously it was needed to replace the `cli-entrypoint` name in the docs generation script. It's no longer needed since the command group is now properly labeled.