### PR TITLE
fix(requirements): updating requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,6 @@ black~=22.12.0
 ipython~=8.7.0
 isort~=5.11.4
 mypy~=0.991
+pytest-xdist~=3.1.0
 pytest~=7.2.0
+types-tabulate~=0.9.0.0


### PR DESCRIPTION
# Description

Previously I forgot to add the `types-tabulate` and `pytest-xdist` libraries to the `requirements-dev.txt` file.